### PR TITLE
build: PySide6 upgraded to 6.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "PySide6~=6.8.2",
+    "PySide6>=6.8,<=6.9.0",
     "qtpy~=2.4",
     "python-lsp-server[all,websockets] ~= 1.12",
 ]


### PR DESCRIPTION
## Description

Upgrade PySide6 to 6.9.0 to be compatible with Qt-ADS on the Bec Widget.