### PR TITLE
build(qt): unlock PySide6 dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "PySide6>=6.8,<=6.9.0",
+    "PySide6>=6.8",
     "qtpy~=2.4",
     "python-lsp-server[all,websockets] ~= 1.12",
 ]


### PR DESCRIPTION
## Description

Testing BW with newest PySide and this one keeps me from running CI: https://github.com/bec-project/bec_widgets/actions/runs/23198413041/job/67413324545?pr=1103#logs
