### PR TITLE
Bugfix/qt and popen

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "PySide6>=6.8,<=6.9.0",
+
     "qtpy~=2.4",
     "python-lsp-server[all,websockets] ~= 1.12",
 ]
@@ -28,6 +28,15 @@ dev = [
     "pytest-xvfb~=3.0",
     "pytest~=8.0",
     "pytest-cov~=6.1.1",
+]
+
+pyside6 = [
+    "PySide6>=6.8",
+]
+
+pyqt6 = [
+    "Pyqt6",
+    "PyQtWebEngine"
 ]
 
 [project.urls]

--- a/qtmonaco/pylsp_provider.py
+++ b/qtmonaco/pylsp_provider.py
@@ -3,6 +3,7 @@ import logging
 import signal
 import socket
 import subprocess
+import sys
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +32,7 @@ class PyLSPProvider:
         # Here you would start the PyLSP server using the found port
         logger.info(f"Starting PyLSP server on port {self.port}")
         self.server_process = subprocess.Popen(
-            ["pylsp", "--ws", "--port", str(self.port)],
+            [sys.executable, "-m", "pylsp", "--ws", "--port", str(self.port)],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )


### PR DESCRIPTION
## Description

The change is related to two small issues:

* starting the pylsp server when in a python environment
* adding optional dependencies for the qtbackends

## Related Issues

For both points I could not make it work. For the qtbackend issue I add to install the newest pyside6 version (removal of the upper version restriction)

## Type of Change

* starting the pylsp server when in a python environment: calling with the env python interpreter the right python module
* adding optional dependencies for the qtbackends

## How to test

- install both optional dependencies and see

## Potential side effects

need to remember to install a valid qt backend either manually or with the optional dependency. The upper restriction removal on pyside6 could cause later some issues but well one has to follow the flow of developement of other projects


## Additional Comments

I'm going to start using that project and monaco editor within the PyMoDAQ project: https://pymodaq.cnrs.fr . it is therefore important to have compatibilities between both. PyMoDAQ also uses qtpy with either pyqt6 or pyside6 backends. 


