### PR TITLE
Bugfix/page import qt5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        qt-framework: [pyside6, pyqt6]
+        qt-framework: [pyside6, pyqt6, pyqt5]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ pyside6 = ["PySide6>=6.8"]
 
 pyqt6 = ["PyQt6", "PyQt6-WebEngine"]
 
+pyqt5 = ["PyQt5", "PyQtWebEngine"]
+
 [project.urls]
 "Bug Tracker" = "https://github.com/bec-project/qtmonaco/issues"
 Homepage = "https://github.com/bec-project/qtmonaco"

--- a/qtmonaco/monaco_page.py
+++ b/qtmonaco/monaco_page.py
@@ -1,6 +1,9 @@
 import logging
 
-from qtpy.QtWebEngineCore import QWebEnginePage
+try:
+    from qtpy.QtWebEngineCore import QWebEnginePage
+except ImportError:
+    from qtpy.QtWebEngineWidgets import QWebEnginePage
 
 logger = logging.getLogger(__name__)
 

--- a/qtmonaco/monaco_page.py
+++ b/qtmonaco/monaco_page.py
@@ -1,9 +1,12 @@
 import logging
 
-try:
-    from qtpy.QtWebEngineCore import QWebEnginePage
-except ImportError:
+from qtpy import PYQT5
+
+if PYQT5:
     from qtpy.QtWebEngineWidgets import QWebEnginePage
+else:
+    from qtpy.QtWebEngineCore import QWebEnginePage
+
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description

This PR allows the use of pyqt5 as a backend. The main difference is the import of the QWebEnginePage class from different modules.

## Type of Change

- add pyqt5 optional dependency with pyqt5 package and PyQtWebEngine packages
- add a try except statement to import QWebEnginePage 
- add a pyqt5 test in the qt matrix

## How to test

- see your usual tests

## Potential side effects
nothing


