### PR TITLE
feat: remove pylint from strict dependencies; add [all] flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ QTMonaco requires either PySide6 or PyQt6 as a Qt backend. Install with your pre
 
 **With PySide6 (recommended):**
 ```bash
-pip install qtmonaco[pyside6]
+pip install qtmonaco[all,pyside6]
 ```
 
 **With PyQt6:**
 ```bash
-pip install qtmonaco[pyqt6]
+pip install qtmonaco[all,pyqt6]
 ```
 
 If you already have a Qt framework installed, you can install QTMonaco without the extra dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,13 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering",
 ]
-dependencies = ["qtpy~=2.4", "python-lsp-server[all,websockets] ~= 1.12"]
+dependencies = [
+    "qtpy~=2.4",
+    "python-lsp-server[autopep8, flake8, mccabe, pycodestyle, pydocstyle, pyflakes, rope, yapf,websockets] ~= 1.12",
+]
 
 [project.optional-dependencies]
+all = ["python-lsp-server[all, websockets] ~= 1.12"]
 dev = [
     "coverage~=7.0",
     "isort~=5.13, >=5.13.2",


### PR DESCRIPTION
## Description

This PR removes pylint as strict dependency through `python-lsp-server[all]` and instead moves it to an optional dependency. 

## Related Issues

#36 

## Type of Change

- Unwrap `python-lsp-server`'s [all] statement and skip pylint
- Add new [all] flag to install everything 

## Potential side effects

pylint is not included anymore by default


## Definition of Done
- [x] Documentation is up-to-date.

